### PR TITLE
Fix the homepage for the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "touch",
     "drag"
   ],
-  "homepage": "http://sachinchoolur.github.io/lg-fullscreen.js",
+  "homepage": "http://sachinchoolur.github.io/lightgallery.js/",
   "bugs": {
     "url": "https://github.com/sachinchoolur/lg-fullscreen.js/issues"
   },


### PR DESCRIPTION
This repository does not have its own dedicated github pages website.